### PR TITLE
Always restart updater systemd service on failures.

### DIFF
--- a/templates/flatcar-image-updater.service
+++ b/templates/flatcar-image-updater.service
@@ -10,7 +10,8 @@ Environment=LATEST_IMAGES_COUNT=${latest_images_count}
 Environment=SLEEP_DURATION=${sleep_duration}
 ExecStartPre=/usr/bin/mkdir -p ${assets_path}
 ExecStart=/opt/flatcar/flatcar-image-updater
-Restart=on-failure
+Restart=always
+RestartSec=20
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
We saw a case where this was failing due to:
```
localhost systemd[1]: Dependency failed for flatcar-image-updater.service - Flatcar Image Updater Service.
localhost systemd[1]: flatcar-image-updater.service: Job flatcar-image-updater.service/start failed with result 'dependency'.
```
where the only dependency seems to be mounting a matchbox volume. We can safely keep restarting this service on any failure (previously Restart=on-failure should only be covering scenarios where the process exits) and be gentle on intervals as we are not in a huge rush to fecth new images after startup.